### PR TITLE
Mark new range specs as pending.

### DIFF
--- a/expand_test.go
+++ b/expand_test.go
@@ -15,6 +15,9 @@ import (
 
 // range-specs that are not currently implemented
 var PendingList = []string{
+	"spec/expand/simple/lookup.spec:19",
+	"spec/expand/simple/lookup.spec:24",
+	"spec/expand/simple/lookup.spec:29",
 }
 
 func TestExpand(t *testing.T) {


### PR DESCRIPTION
@eam @drcapulet @jeeyoungk 

I was messing around with haskell parsing libraries last night and using range as a test case. Figured out conceptually what was wrong in my understanding that was causing this case of bug (there have been a few similar to this). Haven't tried to map that to a fix in the PEG parser yet, I want to play around with it some more first to make sure I have it right.

Ref https://github.com/square/range-spec/pull/15