### PR TITLE
pinning version of upstream testcases repo, using concurrent-go maps

### DIFF
--- a/script/ci
+++ b/script/ci
@@ -3,4 +3,8 @@
 export RANGE_SPEC_PATH=/tmp/range-spec
 git clone https://github.com/square/range-spec.git $RANGE_SPEC_PATH
 
+# pinning upstream spec repo
+pushd $RANGE_SPEC_PATH;
+git checkout 54769a7ebb70dc1b51af0c51317a61c1f76e6f03
+popd
 go test


### PR DESCRIPTION
1. Pinning upsteam spec repo version (to prevent build failures for unimplemented features)
2. Using concurrent-map library to make concurrent read and write capable map for go1.6+ versions