### PR TITLE
limitting parallelism to 2

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -87,6 +87,9 @@ var (
 	// The default cluster for new states, used by @ and ? syntax. Can be changed
 	// per-state using SetDefaultCluster.
 	DefaultCluster = "GROUPS"
+
+	// Parallelism to be used while building primeCache
+	primeCacheParallelismFactor = 2
 )
 
 // Clusters is a getter for all clusters that have been added to the state.
@@ -139,11 +142,10 @@ func (state *State) PrimeCache() []error {
 	// splitting clusters in slices and spawn go routine for each
 	startTime := time.Now()
 	clusters := state.clusterNamesAsArray()
-	parallelism := 2
-	arrayOfClusterSlices := splitIntoSlices(clusters, parallelism)
+	arrayOfClusterSlices := splitIntoSlices(clusters, primeCacheParallelismFactor)
 	var wg sync.WaitGroup
-	resultCh := make(chan mapset.Set, parallelism)
-	errorCh := make(chan []error, parallelism)
+	resultCh := make(chan mapset.Set, primeCacheParallelismFactor)
+	errorCh := make(chan []error, primeCacheParallelismFactor)
 	defer close(resultCh)
 	defer close(errorCh)
 	for _, slice := range arrayOfClusterSlices {

--- a/evaluator.go
+++ b/evaluator.go
@@ -135,14 +135,15 @@ func (state *State) SetDefaultCluster(name string) {
 // necessarily a critical problem, often errors will be in obscure keys, but
 // you should probably try to fix them.
 func (state *State) PrimeCache() []error {
-	// Limiting parallelism to 8 (randomly chosen)
+	// Limiting parallelism to 2
 	// splitting clusters in slices and spawn go routine for each
 	startTime := time.Now()
 	clusters := state.clusterNamesAsArray()
-	arrayOfClusterSlices := splitIntoSlices(clusters, 8)
+	parallelism := 2
+	arrayOfClusterSlices := splitIntoSlices(clusters, parallelism)
 	var wg sync.WaitGroup
-	resultCh := make(chan mapset.Set, 8)
-	errorCh := make(chan []error, 8)
+	resultCh := make(chan mapset.Set, parallelism)
+	errorCh := make(chan []error, parallelism)
 	defer close(resultCh)
 	defer close(errorCh)
 	for _, slice := range arrayOfClusterSlices {


### PR DESCRIPTION
8 go routines running in parallel caused CPU and memory spikes when ever there is a state reload. 
After experimenting with different parallelism values, 2 is perfect compromise. so limiting it to 2. 