### PR TITLE
Make golang-set work with dep

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -10,8 +10,8 @@ import (
 
 	"time"
 
+	"github.com/deckarep/golang-set"
 	"github.com/orcaman/concurrent-map"
-	"gopkg.in/deckarep/v1/golang-set"
 )
 
 // State holds data that queries operate over. Queries in grange are


### PR DESCRIPTION
Change gopkg.in/deckarep/v1/golang-set to github.com/deckarep/golang-set because dep doesn't handle the former