### PR TITLE
Use canonical import path for golang-set

### DIFF
--- a/evaluator.go
+++ b/evaluator.go
@@ -11,8 +11,8 @@ import (
 
 	"time"
 
+	"github.com/deckarep/golang-set"
 	"github.com/orcaman/concurrent-map"
-	"gopkg.in/deckarep/v1/golang-set"
 )
 
 // State holds data that queries operate over. Queries in grange are

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"gopkg.in/deckarep/v1/golang-set"
+	"github.com/deckarep/golang-set"
 )
 
 func TestEmptyQuery(t *testing.T) {


### PR DESCRIPTION
The README for the "golang-set" package links to its own documentation
using the import path "github.com/deckarep/golang-set", even though the
package is available through gopkg.in. I take that self-reference as a
declaration of import path that should be used.

This change also fixes a problem using grange with go1.11's new module
system: the import path "gopkg.in/deckarep/v1/golang-set" does not
follow the new conventions for encoding package major versions and thus
causes import errors.