### PR TITLE
Use Go modules

### DIFF
--- a/expand_test.go
+++ b/expand_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"gopkg.in/v1/yaml"
+	"gopkg.in/yaml.v1"
 )
 
 // range-specs that are not currently implemented

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/square/grange
+
+go 1.12
+
+require (
+	github.com/deckarep/golang-set v0.0.0-20170202203032-fc8930a5e645
+	github.com/orcaman/concurrent-map v0.0.0-20160823150647-8bf1e9bacbf6
+	github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 // indirect
+	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 // indirect
+	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
+	vbom.ml/util v0.0.0-20150502001426-d600ec780753
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/deckarep/golang-set v0.0.0-20170202203032-fc8930a5e645 h1:P2qhNT0y1A7XeBvSwkvXV2nZTd28Ax5n709pred+3Ys=
+github.com/deckarep/golang-set v0.0.0-20170202203032-fc8930a5e645/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
+github.com/orcaman/concurrent-map v0.0.0-20160823150647-8bf1e9bacbf6 h1:df8k17NbGFBiBwHnkSCGQ3F9c6TrF8zmGs2jJ9OsQGc=
+github.com/orcaman/concurrent-map v0.0.0-20160823150647-8bf1e9bacbf6/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
+github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1 h1:j2hhcujLRHAg872RWAV5yaUrEjHEObwDv3aImCaNLek=
+github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=
+vbom.ml/util v0.0.0-20150502001426-d600ec780753 h1:MII8yAzDXvinFxTNdVoUV+OSDNhfp6oB7ha7KAqHPa0=
+vbom.ml/util v0.0.0-20150502001426-d600ec780753/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=


### PR DESCRIPTION
Use the canonical import path for "gopkg.in/yaml.v1" to fix module import errors, then convert the repo to a Go module. Listed dependencies are aged appropriately to reflect active development.